### PR TITLE
adjust yarn installation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Using `npm` (use `--save` to include it in your package.json)
 $ npm install react-rangeslider --save
 ```
 
-Using `yarn` (use `--dev` to include it in your package.json)
+Using `yarn` (this command also adds react-rangeslider to your package.json dependencies)
 
 ```bash
-$ yarn add react-rangeslider --dev
+$ yarn add react-rangeslider
 ```
 
 


### PR DESCRIPTION
yarn does not require a `--save` flag to include the package in package.json dependencies

the `--dev` flag would add the package to the devDependencies of the package.json file