### PR TITLE
Fix for touch screen use in internet explorer

### DIFF
--- a/src/rangeslider.less
+++ b/src/rangeslider.less
@@ -5,6 +5,8 @@
   margin: 20px 0;
   position: relative;
   background: #e6e6e6;
+  -ms-touch-action: none;
+  touch-action: none;
 
   &, .rangeslider__fill {
     display: block;


### PR DESCRIPTION
For whatever reason ie intercepts the slide event when using a touch screen so the handle won't slide. This css prevents that and the event is then handled as desired--the slider handle moves/updates. Tested in Win. 8.1 in IE 11.