### PR TITLE
Use ResizeObserver for detecting resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "webpack-hot-middleware": "^2.10.0"
   },
   "dependencies": {
-    "classnames": "^2.2.3"
+    "classnames": "^2.2.3",
+    "resize-observer-polyfill": "^1.4.2"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"

--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -2,6 +2,7 @@
 import cx from 'classnames'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import ResizeObserver from 'resize-observer-polyfill'
 import { capitalize, clamp } from './utils'
 
 /**
@@ -61,12 +62,9 @@ class Slider extends Component {
   }
 
   componentDidMount () {
-    window.addEventListener('resize', this.handleUpdate)
     this.handleUpdate()
-  }
-
-  componentWillUnmount () {
-    window.removeEventListener('resize', this.handleUpdate)
+    const resizeObserver = new ResizeObserver(this.handleUpdate)
+    resizeObserver.observe(this.slider)
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2195,19 +2195,7 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   dependencies:
     bser "^1.0.2"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
-fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -3633,13 +3621,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
-  dependencies:
-    js-tokens "^2.0.0"
-
-loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4883,6 +4865,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+resize-observer-polyfill@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.4.2.tgz#a37198e6209e888acb1532a9968e06d38b6788e5"
 
 resolve-from@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This uses the lightweight [`resize-observer-polyfill`](https://github.com/que-etc/resize-observer-polyfill) which has great [browser support](https://github.com/que-etc/resize-observer-polyfill#browser-support) for detecting element resizes.

For more information on `ResizeObserver` take a look at: https://developers.google.com/web/updates/2016/10/resizeobserver

At the moment `react-rangeslider` only listens to [global resize events](https://github.com/whoisandie/react-rangeslider/blob/29891e4559dcf644db07c21321776d8f46168bb2/src/Rangeslider.js#L63). Using `ResizeObserver` allows to correctly compute the slider in cases where elements change size without the main window having been resized.

Fixes #62 