### PR TITLE
Updated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "jest": "^15.1.1",
     "less": "^2.7.2",
     "less-loader": "^2.2.3",
+    "less-plugin-clean-css": "^1.5.1",
     "marked": "^0.3.6",
     "opn-cli": "^3.1.0",
     "prop-types": "^15.5.9",


### PR DESCRIPTION
Added missing package "less-plugin-clean-css" in Package.json

It was giving me an error on pm run build

> Unable to interpret argument clean-css - if it is a plugin (less-plugin-clean-css), make sure that it is installed under or at the same level as less