### PR TITLE
Add focus + accessibility support

### DIFF
--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -132,7 +132,8 @@ class Slider extends Component {
 
     let value = this.position(e)
     if (
-      target.classList.contains('rangeslider__label') && target.dataset.value
+      target.classList.contains('rangeslider__label') &&
+      target.dataset.value
     ) {
       value = parseFloat(target.dataset.value)
     }
@@ -149,6 +150,29 @@ class Slider extends Component {
     onChangeComplete && onChangeComplete(e)
     document.removeEventListener('mousemove', this.handleDrag)
     document.removeEventListener('mouseup', this.handleEnd)
+  };
+
+  /**
+   * Support for key events on the slider handle
+   * @param  {Object} e - Event object
+   * @return {void}
+   */
+  handleKeyDown = e => {
+    const { keyCode } = e
+    const { value, onChange, min, max, step } = this.props
+
+    switch (keyCode) {
+      case 38:
+      case 39:
+        e.preventDefault()
+        onChange(value + step > max ? max : value + step, e)
+        break
+      case 37:
+      case 40:
+        e.preventDefault()
+        onChange(value - step < min ? min : value - step, e)
+        break
+    }
   };
 
   /**
@@ -219,12 +243,12 @@ class Slider extends Component {
     const { orientation } = this.props
     const value = this.getValueFromPosition(pos)
     const handlePos = this.getPositionFromValue(value)
-    const sumHandleposGrab = orientation === 'horizontal'
-      ? handlePos + grab
-      : handlePos
-    const fillPos = orientation === 'horizontal'
-      ? sumHandleposGrab
-      : limit - sumHandleposGrab
+    const sumHandleposGrab =
+      orientation === 'horizontal' ? handlePos + grab : handlePos
+    const fillPos =
+      orientation === 'horizontal'
+        ? sumHandleposGrab
+        : limit - sumHandleposGrab
 
     return {
       fill: fillPos,
@@ -234,7 +258,15 @@ class Slider extends Component {
   };
 
   render () {
-    const { value, orientation, className, tooltip, reverse } = this.props
+    const {
+      value,
+      orientation,
+      className,
+      tooltip,
+      reverse,
+      min,
+      max
+    } = this.props
     const dimension = constants.orientation[orientation].dimension
     const direction = reverse
       ? constants.orientation[orientation].reverseDirection
@@ -297,6 +329,10 @@ class Slider extends Component {
         onMouseUp={this.handleEnd}
         onTouchStart={this.handleDrag}
         onTouchEnd={this.handleEnd}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-orientation={orientation}
       >
         <div className='rangeslider__fill' style={fillStyle} />
         <div
@@ -307,9 +343,11 @@ class Slider extends Component {
           onMouseDown={this.handleStart}
           onTouchMove={this.handleDrag}
           onTouchEnd={this.handleEnd}
+          onKeyDown={this.handleKeyDown}
           style={handleStyle}
+          tabIndex={0}
         >
-          {tooltip &&
+          {tooltip && (
             <div
               ref={st => {
                 this.tooltip = st
@@ -317,7 +355,8 @@ class Slider extends Component {
               className='rangeslider__tooltip'
             >
               <span>{this.handleFormat(value)}</span>
-            </div>}
+            </div>
+          )}
         </div>
         {labels}
       </div>

--- a/src/__tests__/__snapshots__/Rangeslider.spec.js.snap
+++ b/src/__tests__/__snapshots__/Rangeslider.spec.js.snap
@@ -1,5 +1,9 @@
 exports[`Rangeslider specs should render basic slider with defaults 1`] = `
 <div
+  aria-orientation="horizontal"
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={0}
   className="rangeslider rangeslider-horizontal"
   onMouseDown={[Function anonymous]}
   onMouseUp={[Function anonymous]}
@@ -14,6 +18,7 @@ exports[`Rangeslider specs should render basic slider with defaults 1`] = `
     } />
   <div
     className="rangeslider__handle"
+    onKeyDown={[Function anonymous]}
     onMouseDown={[Function anonymous]}
     onTouchEnd={[Function anonymous]}
     onTouchMove={[Function anonymous]}
@@ -21,7 +26,8 @@ exports[`Rangeslider specs should render basic slider with defaults 1`] = `
       Object {
         "left": "0px"
       }
-    }>
+    }
+    tabIndex={0}>
     <div
       className="rangeslider__tooltip">
       <span>
@@ -34,6 +40,10 @@ exports[`Rangeslider specs should render basic slider with defaults 1`] = `
 
 exports[`Rangeslider specs should render slider when props passed in 1`] = `
 <div
+  aria-orientation="horizontal"
+  aria-valuemax={50}
+  aria-valuemin={10}
+  aria-valuenow={20}
   className="rangeslider rangeslider-horizontal"
   onMouseDown={[Function anonymous]}
   onMouseUp={[Function anonymous]}
@@ -48,6 +58,7 @@ exports[`Rangeslider specs should render slider when props passed in 1`] = `
     } />
   <div
     className="rangeslider__handle"
+    onKeyDown={[Function anonymous]}
     onMouseDown={[Function anonymous]}
     onTouchEnd={[Function anonymous]}
     onTouchMove={[Function anonymous]}
@@ -55,7 +66,8 @@ exports[`Rangeslider specs should render slider when props passed in 1`] = `
       Object {
         "left": "0px"
       }
-    }>
+    }
+    tabIndex={0}>
     <div
       className="rangeslider__tooltip">
       <span>

--- a/src/rangeslider.less
+++ b/src/rangeslider.less
@@ -8,7 +8,8 @@
   -ms-touch-action: none;
   touch-action: none;
 
-  &, .rangeslider__fill {
+  &,
+  .rangeslider__fill {
     display: block;
     box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.4);
   }
@@ -18,9 +19,9 @@
     cursor: pointer;
     display: inline-block;
     position: absolute;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.4),
-                0 -1px 3px rgba(0,0,0,0.4);
-    &:hover {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 -1px 3px rgba(0, 0, 0, 0.4);
+    &:hover,
+    &:focus {
       .rangeslider__tooltip {
         opacity: 1;
       }
@@ -62,7 +63,7 @@
   .rangeslider__fill {
     height: 100%;
     // background-color: #4CAF50;
-    background-color: #7CB342;
+    background-color: #7cb342;
     border-radius: 10px;
     top: 0;
   }
@@ -80,8 +81,8 @@
       left: 6px;
       border-radius: 50%;
       background-color: #dadada;
-      box-shadow: 0 1px 3px rgba(0,0,0,0.4) inset,
-                  0 -1px 3px rgba(0,0,0,0.4) inset;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4) inset,
+        0 -1px 3px rgba(0, 0, 0, 0.4) inset;
     }
   }
   .rangeslider__tooltip {
@@ -105,13 +106,14 @@
   max-width: 10px;
   background-color: transparent;
 
-  .rangeslider__fill, .rangeslider__handle {
+  .rangeslider__fill,
+  .rangeslider__handle {
     position: absolute;
   }
 
   .rangeslider__fill {
     width: 100%;
-    background-color: #7CB342;
+    background-color: #7cb342;
     box-shadow: none;
     bottom: 0;
   }


### PR DESCRIPTION
Covers most of what was highlighted in #50:

- `tabIndex`
- `aria-valuemin`
- `aria-valuemax`
- `aria-valuemax`
- `aria-orientation`

The arrow keys `←` `↑` `→` `↓` also move the handle when keyboard focus is applied

Jest snapshots have been updated to accommodate the new attributes

Apologies that [`prettier`](https://github.com/prettier/prettier) went to town a bit on some of the existing inline ternary statements. I've tried to minimise the effect, but have a few have been left over. `eslint` is still happy, but I don't mind reverting those changes if you'd prefer 👍 