### PR TITLE
Ensure other key presses work as usual when the slider handle has focus

### DIFF
--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -167,7 +167,6 @@ class Slider extends Component {
    * @return {void}
    */
   handleKeyDown = e => {
-    e.preventDefault()
     const { keyCode } = e
     const { value, min, max, step, onChange } = this.props
     let sliderValue
@@ -175,11 +174,13 @@ class Slider extends Component {
     switch (keyCode) {
       case 38:
       case 39:
+        e.preventDefault()
         sliderValue = value + step > max ? max : value + step
         onChange && onChange(sliderValue, e)
         break
       case 37:
       case 40:
+        e.preventDefault()
         sliderValue = value - step < min ? min : value - step
         onChange && onChange(sliderValue, e)
         break


### PR DESCRIPTION
Unfortunately my last PR was calling `e.preventDefault()` on all key presses after the slider handle had gained focus. This was preventing a user from tabbing to the next focusable element, or to any previous element. This restores that functionality, while keeping the arrow key controls.