### PR TITLE
bug: fix bug on display of 'fill' on horizontal reversed slide bar

### DIFF
--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -251,11 +251,11 @@ class Slider extends Component {
    */
   coordinates = pos => {
     const { limit, grab } = this.state
-    const { orientation } = this.props
+    const { orientation, reverse } = this.props
     const value = this.getValueFromPosition(pos)
     const position = this.getPositionFromValue(value)
     const handlePos = orientation === 'horizontal' ? position + grab : position
-    const fillPos = orientation === 'horizontal'
+    const fillPos = orientation === 'horizontal' && !reverse
       ? handlePos
       : limit - handlePos
 
@@ -366,7 +366,7 @@ class Slider extends Component {
                 this.tooltip = st
               }}
               className='rangeslider__handle-tooltip'
-              >
+            >
               <span>{this.handleFormat(value)}</span>
             </div>
             : null}


### PR DESCRIPTION
![20170925163905](https://user-images.githubusercontent.com/5256278/30829916-3e790764-a210-11e7-9a83-e895dc3167f4.png)
The filled part for the reversed horizontal bar (the last one in the picture) was not behaving as expected. 