### PR TITLE
Make tabIndex configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ import Slider from 'react-rangeslider'
   tooltip={Boolean}
   labels={Object}
   handleLabel={String}
+  tabIndex={Number}
   format={Function}
   onChangeStart={Function}
   onChange={Function}
@@ -139,6 +140,7 @@ Prop   	 			 |  Type      |  Default      |  Description
 `reverse`  		 |  boolean   |  false			  |  reverse direction of vertical slider (top-bottom)
 `labels`       |  object    |  {}           |  object containing key-value pairs. `{ 0: 'Low', 50: 'Medium', 100: 'High'}`
 `handleLabel`  |  string    |  ''           |  string label to appear inside slider handles
+`tabIndex`     |  number    |  1            |  tabIndex passed to the slider handle.
 `format`     |  function  |               |  function to format and display the value in label or tooltip
 `onChangeStart`  	 |  function  |               |  function gets called whenever the user starts dragging the slider handle
 `onChange`  	 |  function  |               |  function gets called whenever the slider handle is being dragged or clicked

--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -37,11 +37,11 @@ class Slider extends Component {
     reverse: PropTypes.bool,
     labels: PropTypes.object,
     handleLabel: PropTypes.string,
+    tabIndex: PropTypes.number,
     format: PropTypes.func,
     onChangeStart: PropTypes.func,
     onChange: PropTypes.func,
-    onChangeComplete: PropTypes.func,
-    tabIndex: PropTypes.number
+    onChangeComplete: PropTypes.func
   };
 
   static defaultProps = {

--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -40,7 +40,8 @@ class Slider extends Component {
     format: PropTypes.func,
     onChangeStart: PropTypes.func,
     onChange: PropTypes.func,
-    onChangeComplete: PropTypes.func
+    onChangeComplete: PropTypes.func,
+    tabIndex: PropTypes.number
   };
 
   static defaultProps = {
@@ -52,7 +53,8 @@ class Slider extends Component {
     tooltip: true,
     reverse: false,
     labels: {},
-    handleLabel: ''
+    handleLabel: '',
+    tabIndex: 0
   };
 
   constructor (props, context) {
@@ -287,7 +289,8 @@ class Slider extends Component {
       labels,
       min,
       max,
-      handleLabel
+      handleLabel,
+      tabIndex
     } = this.props
     const { active } = this.state
     const dimension = constants.orientation[orientation].dimension
@@ -358,7 +361,7 @@ class Slider extends Component {
           onTouchEnd={this.handleEnd}
           onKeyDown={this.handleKeyDown}
           style={handleStyle}
-          tabIndex={0}
+          tabIndex={tabIndex}
         >
           {showTooltip
             ? <div


### PR DESCRIPTION
Currently the tabIndex attribute is hardcoded (value = 0). This PR changes the component to use the tabIndex from props. Default to 0. 

**Why:**
I'm using this lib and I want to make the slider unfocusable. By making the tabIndex configurable I would be able to pass -1 (which disables focus). 

It will also help anyone who needs to override the tabIndex order.