### PR TITLE
Don't capture keyDown if sliderValue isn't set

### DIFF
--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -167,23 +167,28 @@ class Slider extends Component {
    * @return {void}
    */
   handleKeyDown = e => {
-    e.preventDefault()
-    const { keyCode } = e
     const { value, min, max, step, onChange } = this.props
+    
+    if (!onChange) return
+    
+    const { keyCode } = e
     let sliderValue
 
     switch (keyCode) {
       case 38:
       case 39:
         sliderValue = value + step > max ? max : value + step
-        onChange && onChange(sliderValue, e)
         break
       case 37:
       case 40:
         sliderValue = value - step < min ? min : value - step
-        onChange && onChange(sliderValue, e)
         break
+      default:
+        return
     }
+    
+    e.preventDefault()
+    onChange(sliderValue, e)
   };
 
   /**

--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -168,9 +168,9 @@ class Slider extends Component {
    */
   handleKeyDown = e => {
     const { value, min, max, step, onChange } = this.props
-    
+
     if (!onChange) return
-    
+
     const { keyCode } = e
     let sliderValue
 
@@ -186,7 +186,7 @@ class Slider extends Component {
       default:
         return
     }
-    
+
     e.preventDefault()
     onChange(sliderValue, e)
   };


### PR DESCRIPTION
This is a change which allows for greater keyboard accessibility. Currently, `e.preventDefault()` is always called, regardless of whether we used an arrow key, or whether there is an  `onChange` handler. This stops us from using Tab to move focus to another control outside this component (it's effectively trapped until we blur using a pointer input).

I've tried my best to fit your code style (exit early).