### PR TITLE
fix reversed horizontal fill and handle position

### DIFF
--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -254,8 +254,8 @@ class Slider extends Component {
     const { orientation, reverse } = this.props
     const value = this.getValueFromPosition(pos)
     const position = this.getPositionFromValue(value)
-    const handlePos = orientation === 'horizontal' && !reverse 
-      ? position + grab 
+    const handlePos = orientation === 'horizontal' && !reverse
+      ? position + grab
       : (reverse ? position - grab : position)
     const fillPos = orientation === 'horizontal' && !reverse
       ? handlePos

--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -251,11 +251,13 @@ class Slider extends Component {
    */
   coordinates = pos => {
     const { limit, grab } = this.state
-    const { orientation } = this.props
+    const { orientation, reverse } = this.props
     const value = this.getValueFromPosition(pos)
     const position = this.getPositionFromValue(value)
-    const handlePos = orientation === 'horizontal' ? position + grab : position
-    const fillPos = orientation === 'horizontal'
+    const handlePos = orientation === 'horizontal' && !reverse 
+      ? position + grab 
+      : (reverse ? position - grab : position)
+    const fillPos = orientation === 'horizontal' && !reverse
       ? handlePos
       : limit - handlePos
 


### PR DESCRIPTION
Horizontal slider don't calculate position of fill and handle right if is reversed.

Screencapture of bug: https://cl.ly/qvgU