### PR TITLE
Add disabled prop to render without interaction

### DIFF
--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -35,6 +35,7 @@ class Slider extends Component {
     orientation: PropTypes.string,
     tooltip: PropTypes.bool,
     reverse: PropTypes.bool,
+    disabled: PropTypes.bool,
     labels: PropTypes.object,
     handleLabel: PropTypes.string,
     format: PropTypes.func,
@@ -52,7 +53,8 @@ class Slider extends Component {
     tooltip: true,
     reverse: false,
     labels: {},
-    handleLabel: ''
+    handleLabel: '',
+    disabled: false
   };
 
   constructor (props, context) {
@@ -303,6 +305,11 @@ class Slider extends Component {
     let labelItems = []
     let labelKeys = Object.keys(labels)
 
+    const handleDrag = (this.props.disabled ? false : this.handleDrag)
+    const handleStart = (this.props.disabled ? false : this.handleStart)
+    const handleEnd = (this.props.disabled ? false : this.handleEnd)
+    const handleKeyDown = (this.props.disabled ? false : this.handleKeyDown)
+
     if (labelKeys.length > 0) {
       labelKeys = labelKeys.sort((a, b) => (reverse ? a - b : b - a))
 
@@ -316,9 +323,9 @@ class Slider extends Component {
             key={key}
             className={cx('rangeslider__label-item')}
             data-value={key}
-            onMouseDown={this.handleDrag}
-            onTouchStart={this.handleStart}
-            onTouchEnd={this.handleEnd}
+            onMouseDown={handleDrag}
+            onTouchStart={handleStart}
+            onTouchEnd={handleEnd}
             style={labelStyle}
           >
             {this.props.labels[key]}
@@ -335,13 +342,16 @@ class Slider extends Component {
         className={cx(
           'rangeslider',
           `rangeslider-${orientation}`,
-          { 'rangeslider-reverse': reverse },
+          {
+            'rangeslider-reverse': reverse,
+            'rangeslider-disabled': this.props.disabled
+          },
           className
         )}
-        onMouseDown={this.handleDrag}
-        onMouseUp={this.handleEnd}
-        onTouchStart={this.handleStart}
-        onTouchEnd={this.handleEnd}
+        onMouseDown={handleDrag}
+        onMouseUp={handleEnd}
+        onTouchStart={handleStart}
+        onTouchEnd={handleEnd}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={value}
@@ -353,10 +363,10 @@ class Slider extends Component {
             this.handle = sh
           }}
           className='rangeslider__handle'
-          onMouseDown={this.handleStart}
-          onTouchMove={this.handleDrag}
-          onTouchEnd={this.handleEnd}
-          onKeyDown={this.handleKeyDown}
+          onMouseDown={handleStart}
+          onTouchMove={handleDrag}
+          onTouchEnd={handleEnd}
+          onKeyDown={handleKeyDown}
           style={handleStyle}
           tabIndex={0}
         >

--- a/src/Rangeslider.js
+++ b/src/Rangeslider.js
@@ -305,10 +305,10 @@ class Slider extends Component {
     let labelItems = []
     let labelKeys = Object.keys(labels)
 
-    const handleDrag = (this.props.disabled ? false : this.handleDrag)
-    const handleStart = (this.props.disabled ? false : this.handleStart)
-    const handleEnd = (this.props.disabled ? false : this.handleEnd)
-    const handleKeyDown = (this.props.disabled ? false : this.handleKeyDown)
+    const handleDrag = (this.props.disabled ? undefined : this.handleDrag)
+    const handleStart = (this.props.disabled ? undefined : this.handleStart)
+    const handleEnd = (this.props.disabled ? undefined : this.handleEnd)
+    const handleKeyDown = (this.props.disabled ? undefined : this.handleKeyDown)
 
     if (labelKeys.length > 0) {
       labelKeys = labelKeys.sort((a, b) => (reverse ? a - b : b - a))

--- a/src/__tests__/Rangeslider.spec.js
+++ b/src/__tests__/Rangeslider.spec.js
@@ -22,6 +22,7 @@ describe('Rangeslider specs', () => {
     expect(slider.prop('reverse')).toEqual(false)
     expect(slider.prop('handleLabel')).toEqual('')
     expect(slider.prop('labels')).toEqual({})
+    expect(slider.prop('disabled')).toEqual(false)
   })
 
   it('should render basic slider with defaults', () => {


### PR DESCRIPTION
Sometimes it can be nice to render a slider that should not be changed by the user. This pull request adds a prop `disabled` that disabled touch, keyboard and click inputs.